### PR TITLE
Fix typo in serve command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build: ## Build the project
 
 .PHONY: serve
 serve: ## Serve the application with a local HTTP server
-	npm run server
+	npm run serve
 
 .PHONY: bundle
 bundle: ## Bundle the JavaScript application


### PR DESCRIPTION
The script in `package.json` is `serve` but in Makefile `server`.