### PR TITLE
consume reason-react with opam

### DIFF
--- a/dune
+++ b/dune
@@ -1,1 +1,5 @@
-(dirs src)
+;; we start by ignoring node_modules. if you need to consume an OCaml 
+;; project from `node_modules`, this should work:
+;; - remove the `dirs` stanza below
+;; - add a `(subdir node_modules (dirs only_your_package))`
+(dirs :standard \ node_modules)

--- a/dune
+++ b/dune
@@ -1,14 +1,1 @@
-(subdir
- node_modules
- (dirs reason-react)
- (data_only_dirs reason-react)
- (subdir
-  reason-react/src
-  (include_subdirs unqualified)
-  (library
-   (name reason_react)
-   (wrapped false)
-   (modes melange)
-   (flags -w -9-27-32-20)
-   (preprocess
-    (pps melange.ppx reactjs-jsx-ppx)))))
+(dirs src)

--- a/melange-opam-template.opam
+++ b/melange-opam-template.opam
@@ -22,5 +22,5 @@ pin-depends: [
   [ "dune.dev" "git+https://github.com/ocaml/dune.git#66573762f28b84268cf04c3c46d0deaef9945316" ]
   [ "melange.dev" "git+https://github.com/melange-re/melange.git#ff0ca826c7b2175ff9208f626c68d960cfcdfcd3" ]
   [ "reactjs-jsx-ppx.dev" "git+https://github.com/melange-re/melange.git#ff0ca826c7b2175ff9208f626c68d960cfcdfcd3" ]
-  [ "reason-react.dev" "git+https://github.com/jchavarri/reason-react.git#d5a5e209817ef9abf7c51a287172870e5cb76643" ]
+  [ "reason-react.dev" "git+https://github.com/jchavarri/reason-react.git#27de44aed71ca4ccc902952e6a3203d663a23bcb" ]
 ]

--- a/melange-opam-template.opam
+++ b/melange-opam-template.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {dev}
   "melange" {dev}
   "reactjs-jsx-ppx" {dev}
+  "reason-react" {dev}
   "ocaml-lsp-server" {dev}
   "dot-merlin-reader" {dev}
   "odoc" {with-doc}
@@ -21,4 +22,5 @@ pin-depends: [
   [ "dune.dev" "git+https://github.com/ocaml/dune.git#66573762f28b84268cf04c3c46d0deaef9945316" ]
   [ "melange.dev" "git+https://github.com/melange-re/melange.git#ff0ca826c7b2175ff9208f626c68d960cfcdfcd3" ]
   [ "reactjs-jsx-ppx.dev" "git+https://github.com/melange-re/melange.git#ff0ca826c7b2175ff9208f626c68d960cfcdfcd3" ]
+  [ "reason-react.dev" "git+https://github.com/jchavarri/reason-react.git#d5a5e209817ef9abf7c51a287172870e5cb76643" ]
 ]

--- a/melange-opam-template.opam
+++ b/melange-opam-template.opam
@@ -22,5 +22,5 @@ pin-depends: [
   [ "dune.dev" "git+https://github.com/ocaml/dune.git#66573762f28b84268cf04c3c46d0deaef9945316" ]
   [ "melange.dev" "git+https://github.com/melange-re/melange.git#ff0ca826c7b2175ff9208f626c68d960cfcdfcd3" ]
   [ "reactjs-jsx-ppx.dev" "git+https://github.com/melange-re/melange.git#ff0ca826c7b2175ff9208f626c68d960cfcdfcd3" ]
-  [ "reason-react.dev" "git+https://github.com/jchavarri/reason-react.git#27de44aed71ca4ccc902952e6a3203d663a23bcb" ]
+  [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#97d31755c8d24fab13d6b60a3980505c917c1244" ]
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,7 @@
     "": {
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "reason-react": "^0.10.1"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "webpack": "^5.73.0",
@@ -2380,16 +2379,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/reason-react": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/reason-react/-/reason-react-0.10.1.tgz",
-      "integrity": "sha512-Yp1+k6Y8Roghd58oaaIzNpoee+P369GIXbmyDmMpy078jDgbvA7hXdbbfyHBl5YmytjKjGLNuALNUsxQJs30Dw==",
-      "peerDependencies": {
-        "bs-platform": "^9.0.2",
-        "react": "^16.8.1",
-        "react-dom": "^16.8.1"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "reason-react": "^0.10.1"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "webpack": "^5.73.0",

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (melange.emit
  (target output)
  (alias react)
- (libraries melange reason_react world)
+ (libraries melange reason-react world)
  (modules :standard \ hello)
  (preprocess
   (pps reactjs-jsx-ppx))


### PR DESCRIPTION
Moves `reason-react` from npm to opam.

Should wait until https://github.com/reasonml/reason-react/pull/720 is merged.