### PR TITLE
remove melange lib

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (melange.emit
  (target output)
  (alias react)
- (libraries melange reason-react world)
+ (libraries reason-react world)
  (modules :standard \ hello)
  (preprocess
   (pps reactjs-jsx-ppx))


### PR DESCRIPTION
No more need to add `melange` in libraries, as dune adds it by default.