### PR TITLE
Add note about missing melange dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ make watch
 make serve
 ```
 
+When running `make init`, you may encounter an error like this:
+
+```
+[ERROR] Could not determine which packages to install for this switch:
+  * Missing dependency:
+    - melange >= 1.0.0
+    no matching version
+```
+
+To address this, first run `opam update`, then rerun `make init`.
+
 ### React
 
 React support is provided by


### PR DESCRIPTION
I've seen a question about this error a couple times (well at least once, but I think it was > 1) on the melange discord, so I figured it would be worth including a note on a solution.

Not sure if this is the ideal location in the readme or the best wording though.