### PR TITLE
`with-dev-setup` in for Opam 2.2 and onwards

### DIFF
--- a/melange-opam-template.opam
+++ b/melange-opam-template.opam
@@ -14,7 +14,6 @@ depends: [
   "reactjs-jsx-ppx" {>= "1.0.0"}
   "reason-react" {>= "0.11.0"}
   "ocaml-lsp-server" {with-dev-setup}
-  "dot-merlin-reader" {with-dev-setup}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/your/project.git"


### PR DESCRIPTION
This replaces the `dev` flag(?) with the `with-dev-setup` flag which can be used by an end user as follows
```
opam install . --with-dev-setup
```

The PR should only be merged after Opam 2.2 has a GA release.