### PR TITLE
fix key warning in demo

### DIFF
--- a/src/ReactApp.re
+++ b/src/ReactApp.re
@@ -4,7 +4,7 @@ module App = {
   [@react.component]
   let make = () =>
     ["Hello " ++ World.name ++ "!", "This is React!"]
-    ->Belt.List.map(greeting => <h1> greeting->React.string </h1>)
+    ->Belt.List.map(greeting => <h1 key={greeting}> greeting->React.string </h1>)
     ->Belt.List.toArray
     ->React.array;
 };


### PR DESCRIPTION
fixes this warning:
<img width="586" alt="image" src="https://github.com/melange-re/melange-opam-template/assets/7026/5d32d175-eaf2-4153-82e6-685c8a9fc503">


before|after
-|-
<img width="129" alt="image" src="https://github.com/melange-re/melange-opam-template/assets/7026/a4834a3e-d6b8-48ec-8e7e-985515515e07">|<img width="223" alt="image" src="https://github.com/melange-re/melange-opam-template/assets/7026/e9223796-81f0-43c6-be60-bf26905c399e">
